### PR TITLE
Add toggle to hide non active alerts

### DIFF
--- a/web/ui/README.md
+++ b/web/ui/README.md
@@ -8,6 +8,7 @@ To make this work, add `-tags dev` to the `flags` entry in `.promu.yml`, and the
 
 This will serve all files from your local filesystem.
 This is for development purposes only.
+Prometheus needs to be started in `web/ui/` directory.
 
 After making changes to any file, run `make assets` before committing to update
 the generated inline version of the file.

--- a/web/ui/static/css/alerts.css
+++ b/web/ui/static/css/alerts.css
@@ -6,17 +6,17 @@
   display: none;
 }
 
-div.show-annotations {
+div.show-annotations, div.show-active {
   font-size: 0.8em;
   padding-top: 1em;
   padding-bottom: 1em;
 }
 
-div.show-annotations:hover {
+div.show-annotations:hover, div.show-active:hover {
   cursor: pointer;
 }
 
-div.show-annotations button {
+div.show-annotations button, div.show-active button {
   background-color: transparent;
   border: none;
   outline: none;
@@ -24,7 +24,7 @@ div.show-annotations button {
   color: inherit;
 }
 
-div.show-annotations.is-checked {
+div.show-annotations.is-checked, div.show-active.is-checked {
   color: #286090;
 }
 

--- a/web/ui/static/js/alerts.js
+++ b/web/ui/static/js/alerts.js
@@ -26,6 +26,57 @@ function init() {
         targetEl.removeClass('is-checked');
     }
   });
+
+  $("div.show-active").click(function() {
+    const targetEl = $('div.show-active');
+    const icon = $(targetEl).children('i');
+    const rootEl = document.querySelector('html body div table tbody').children;
+
+    if (icon.hasClass('glyphicon-unchecked')) {
+        $(".alert_active").show();
+        $(".alert_active_header").show();
+        $(targetEl).children('i').removeClass('glyphicon-unchecked').addClass('glyphicon-check');
+        targetEl.addClass('is-checked');
+
+        // disable all non active alerts
+        for (let curEl  of document.getElementsByClassName('alert-success')) {
+            curEl.style.display="none";
+        }
+        // check if we can disable groups
+        let emptyGroup = true
+        let rowToBeHidden = new Array();
+        let index = rootEl.length - 1;
+        // go from bottem to top to hidde last row
+        while (index >= 0) {
+            if (rootEl[index].className == "") {
+                if (emptyGroup) {
+                    rowToBeHidden.push(rootEl[index]);
+                }
+                emptyGroup = true;
+            } else {
+                if (rootEl[index].className != "alert_details" && rootEl[index].style.display != "none") {
+                    emptyGroup = false;
+                }
+            }
+            index = index - 1;
+        }
+        for (let curEl of rowToBeHidden) {
+            curEl.style.display = "none";
+        }
+    } else if (icon.hasClass('glyphicon-check')) {
+        $(".alert_active").hide();
+        $(".alert_active_header").hide();
+        $(targetEl).children('i').removeClass('glyphicon-check').addClass('glyphicon-unchecked');
+        targetEl.removeClass('is-checked');
+
+        // enable ALL hidden elements
+        for (let curEl of rootEl) {
+            if (curEl.className != "alert_details" && curEl.style.display == "none") {
+                curEl.style.display = "";
+            }
+        }
+    }
+  });
 }
 
 $(init);

--- a/web/ui/templates/alerts.html
+++ b/web/ui/templates/alerts.html
@@ -10,6 +10,10 @@
      <i class="glyphicon glyphicon-unchecked"></i>
        <button type="button" class="show-annotations" title="show annotations">Show annotations</button>
   </div>
+  <div class="show-active">
+     <i class="glyphicon glyphicon-unchecked"></i>
+       <button type="button" class="show-active" title="show only active alerts">Show only active alerts</button>
+  </div>
   <table class="table table-bordered table-collapsed">
     <tbody>
       {{$alertStateToRowClass := .AlertStateToRowClass}}


### PR DESCRIPTION
This does probably not work when an alert changes the state.
This is a workaround to hide non active alerts when looking at the alerts tab in prometheus.
Related to: https://github.com/prometheus/prometheus/pull/5448#issuecomment-516715489

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->